### PR TITLE
Use the Default trait instead of Plugin::new

### DIFF
--- a/examples/skeleton/src/lib.rs
+++ b/examples/skeleton/src/lib.rs
@@ -1,16 +1,13 @@
+use macroquest::eq;
 use macroquest::log::{debug, trace};
-use macroquest::{eq, Plugin};
 
 const VERSION: &str = "1.0";
 
 #[macroquest::plugin(logging(file))]
+#[derive(Default)]
 struct MQRustSkeleton {}
 
 impl macroquest::Plugin for MQRustSkeleton {
-    fn new() -> Self {
-        MQRustSkeleton {}
-    }
-
     fn initialize(&mut self) {
         debug!(version = VERSION, "Initializing");
     }

--- a/macroquest-macros/src/lib.rs
+++ b/macroquest-macros/src/lib.rs
@@ -184,7 +184,7 @@ pub fn plugin(args: TokenStream, stream: TokenStream) -> TokenStream {
             match call_reason {
                 DLL_PROCESS_ATTACH => {
                     #logging
-                    #plugin.replace(Some(#plugin_t::new()))
+                    #plugin.replace(Some(#plugin_t::default()))
                 }
                 DLL_PROCESS_DETACH => #plugin.replace(None),
                 _ => {}

--- a/macroquest/src/lib.rs
+++ b/macroquest/src/lib.rs
@@ -64,7 +64,9 @@ pub use crate::pluginapi::{Plugin, PluginHandler};
 pub mod eq;
 pub mod log;
 pub mod mq;
+
 mod pluginapi;
+
 #[doc(hidden)]
 pub mod windows;
 

--- a/macroquest/src/pluginapi.rs
+++ b/macroquest/src/pluginapi.rs
@@ -15,12 +15,7 @@ use crate::ffi;
 /// a Plugin implementation to implement only the ones that they actually care
 /// about, while leaving the no-op implementations to cover any other hook.
 #[allow(unused_variables)]
-pub trait Plugin {
-    /// This is called to create the instance of the plugin, it should setup
-    /// any basic data structures or other state, but shouldn't generally handle
-    /// initialization.
-    fn new() -> Self;
-
+pub trait Plugin: Default {
     /// This is called once on plugin initialization and can be considered the
     /// startup routine for the plugin.
     fn initialize(&mut self) {}


### PR DESCRIPTION
``Plugin::new`` wasn't really providing any extra value over ``Default::default()``, and ``Default`` can be derived.