### PR TITLE
Refactor WriteChat Handling

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -4,6 +4,8 @@ doc-valid-idents = [
     "MacroQuest2",
     "MQNext",
     "MQ2Main",
+    "MQ2Chat",
+    "MQ2ChatWnd",
     "ImGui",
 ]
 allowed-duplicate-crates = [

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -4,7 +4,6 @@ enum_discrim_align_threshold = 20
 struct_field_align_threshold = 20
 control_brace_style = "ClosingNextLine"
 format_code_in_doc_comments = true
-format_strings = true
 imports_layout = "HorizontalVertical"
 imports_granularity = "Module"
 newline_style = "Unix"

--- a/examples/MQRustLowLevel/Cargo.toml
+++ b/examples/MQRustLowLevel/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-macroquest = { workspace = true, features = ["logger", "colors"] }
+macroquest = { workspace = true, features = ["logger"] }
 
 
 [build-dependencies]

--- a/examples/MQRustSimple/Cargo.toml
+++ b/examples/MQRustSimple/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-macroquest = { workspace = true, features = ["logger", "colors"] }
+macroquest = { workspace = true, features = ["logger"] }
 
 
 [build-dependencies]

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -14,7 +14,8 @@ keywords.workspace = true
 macroquest-sys = { workspace = true, optional = true }
 macroquest-proc-macros = { workspace = true }
 
-cansi = { version = "2.2.1", optional = true }
+cansi = "2.2.1"
+memchr = "2"
 num_enum = "0.7.2"
 parking_lot = "0.12.1"
 ref-cast = "1.0"
@@ -34,7 +35,6 @@ macroquest-build-config = { workspace = true }
 [features]
 default = ["bindings"]
 bindings = ["dep:macroquest-sys"]
-colors = ["dep:cansi"]
 logger = ["dep:tracing-subscriber", "dep:tracing-appender"]
 
 

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -32,6 +32,10 @@ windows = { version = "0.*", features = [
 macroquest-build-config = { workspace = true }
 
 
+[dev-dependencies]
+colored = "2"
+
+
 [features]
 default = ["bindings"]
 bindings = ["dep:macroquest-sys"]

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -18,6 +18,7 @@ cansi = "2.2.1"
 memchr = "2"
 num_enum = "0.7.2"
 parking_lot = "0.12.1"
+once_cell = { version = "1.19.0", features = ["parking_lot"] }
 ref-cast = "1.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -44,7 +44,7 @@ logger = ["dep:tracing-subscriber", "dep:tracing-appender"]
 
 
 [package.metadata.docs.rs]
-features = ["colors", "logger"]
+features = ["logger"]
 no-default-features = true
 targets = ["x86_64-pc-windows-msvc"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/macroquest/src/log.rs
+++ b/macroquest/src/log.rs
@@ -11,12 +11,6 @@ pub mod logger {
 
     use crate::mq;
 
-    #[cfg(feature = "colors")]
-    const SHOULD_COLOR: bool = true;
-
-    #[cfg(not(feature = "colors"))]
-    const SHOULD_COLOR: bool = false;
-
     pub fn init<F>(
         console_filter: Option<LevelFilter>,
         file_opts: Option<(LevelFilter, F)>,
@@ -28,7 +22,7 @@ pub mod logger {
                 .with_writer(mq::console)
                 .event_format(
                     tracing_subscriber::fmt::format()
-                        .with_ansi(SHOULD_COLOR)
+                        .with_ansi(true)
                         .without_time(),
                 )
                 .with_filter(filter)

--- a/macroquest/src/log.rs
+++ b/macroquest/src/log.rs
@@ -25,7 +25,7 @@ pub mod logger {
     {
         let console_layer = console_filter.map(|filter| {
             tracing_subscriber::fmt::layer()
-                .with_writer(mq::ConsoleWriter::new)
+                .with_writer(mq::console)
                 .event_format(
                     tracing_subscriber::fmt::format()
                         .with_ansi(SHOULD_COLOR)

--- a/macroquest/src/mq.rs
+++ b/macroquest/src/mq.rs
@@ -6,6 +6,8 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::sync::OnceLock;
 
+use cansi::{Color, Intensity};
+
 use crate::eq::ChatColor;
 use crate::ffi::mq as mqlib;
 
@@ -88,22 +90,84 @@ pub fn paths() -> &'static Paths<'static> {
 }
 
 #[allow(missing_docs)]
-pub fn write_chat_color<'a, S>(line: S, color: ChatColor)
-where
-    S: Into<Cow<'a, str>>,
-{
-    match line.into() {
-        Cow::Borrowed(s) => mqlib::write_chat_color(s, color.into()),
-        Cow::Owned(s) => mqlib::write_chat_color(s.as_str(), color.into()),
-    }
-}
-
-#[allow(missing_docs)]
 pub fn write_chat<'a, S>(line: S)
 where
     S: Into<Cow<'a, str>>,
 {
     write_chat_color(line, ChatColor::default());
+}
+
+#[allow(missing_docs)]
+pub fn write_chat_color<'a, S>(line: S, color: ChatColor)
+where
+    S: Into<Cow<'a, str>>,
+{
+    mqlib::write_chat_color(&colorize_line(line.into()), color.into());
+}
+
+fn colorize_line<'a, S>(line: S) -> Cow<'a, str>
+where
+    S: Into<Cow<'a, str>>,
+{
+    let line = line.into();
+    match memchr::memchr(b'\x1b', line.as_bytes()) {
+        Some(_) => {
+            cansi::v3::categorise_text(&line)
+                .iter()
+                .flat_map(|m| {
+                    // We ignore most of the ANSI codes, because WriteChatColor
+                    // doesn't support them in any meaningful way, but we can
+                    // support foreground colors.
+                    match m.fg {
+                        None => ["", "", "", m.text, ""],
+                        Some(fg) => [
+                            // Control character that signifies a color code
+                            "\x07",
+                            // If we have a "Faint" color, then we'll use the darker
+                            // variant of our colors.
+                            match m.intensity.unwrap_or(Intensity::Normal) {
+                                Intensity::Faint => "-",
+                                _ => "",
+                            },
+                            // Map the ANSI colors to the MacroQuest color codes.
+                            //
+                            // MacroQuest supports 10 color codes instead of the
+                            // standard 8, adding Purple and Orange. To support
+                            // these two colors we'll use a similiar color with the
+                            // blink ANSI code set.
+                            match fg {
+                                Color::Black | Color::BrightBlack => "b",
+                                Color::Green | Color::BrightGreen => "g",
+                                Color::Magenta | Color::BrightMagenta => {
+                                    match m.blink {
+                                        // Purple is blinking Magenta.
+                                        Some(true) => "p",
+                                        // Otherwise, regular Magenta.
+                                        _ => "m",
+                                    }
+                                }
+                                Color::Red | Color::BrightRed => "r",
+                                Color::Cyan | Color::BrightCyan => "t",
+                                Color::Blue | Color::BrightBlue => "u",
+                                Color::White | Color::BrightWhite => "w",
+                                Color::Yellow | Color::BrightYellow => match m.blink {
+                                    // Orangle is blinking Yellow.
+                                    Some(true) => "o",
+                                    // Otherwise, regular Yellow.
+                                    _ => "y",
+                                },
+                            },
+                            // The actual text wrapped by this ANSI color code.
+                            m.text,
+                            // The "reset back to the normal color" code.
+                            "\x07x",
+                        ],
+                    }
+                })
+                .collect()
+        }
+        None => line,
+    }
 }
 
 #[allow(missing_docs)]
@@ -129,7 +193,7 @@ impl io::Write for ConsoleWriter {
                 io::Error::new(io::ErrorKind::InvalidInput, e.to_string())
             })?;
 
-            write_chat(colorize(line.trim_end_matches('\n')));
+            write_chat(line.trim_end_matches('\n'));
             written += raw.len();
         }
 
@@ -139,66 +203,4 @@ impl io::Write for ConsoleWriter {
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
     }
-}
-
-#[cfg(feature = "colors")]
-fn colorize(line: &str) -> String {
-    use cansi::{Color, Intensity};
-
-    cansi::v3::categorise_text(line)
-        .iter()
-        .flat_map(|m| {
-            // We ignore most of the ANSI codes, because WriteChatColor
-            // doesn't support them in any meaningful way, but we can
-            // support foreground colors.
-            match m.fg {
-                None => ["", "", "", m.text, ""],
-                Some(fg) => [
-                    // Control character that signifies a color code
-                    "\x07",
-                    // If we have a "Faint" color, then we'll use the darker
-                    // variant of our colors.
-                    match m.intensity.unwrap_or(Intensity::Normal) {
-                        Intensity::Faint => "-",
-                        _ => "",
-                    },
-                    // Map the ANSI colors to the MacroQuest color codes.
-                    //
-                    // MacroQuest supports 10 color codes instead of the
-                    // standard 8, adding Purple and Orange. To support
-                    // these two colors we'll use a similiar color with the
-                    // blink ANSI code set.
-                    match fg {
-                        Color::Black | Color::BrightBlack => "b",
-                        Color::Green | Color::BrightGreen => "g",
-                        Color::Magenta | Color::BrightMagenta => match m.blink {
-                            // Purple is blinking Magenta.
-                            Some(true) => "p",
-                            // Otherwise, regular Magenta.
-                            _ => "m",
-                        },
-                        Color::Red | Color::BrightRed => "r",
-                        Color::Cyan | Color::BrightCyan => "t",
-                        Color::Blue | Color::BrightBlue => "u",
-                        Color::White | Color::BrightWhite => "w",
-                        Color::Yellow | Color::BrightYellow => match m.blink {
-                            // Orangle is blinking Yellow.
-                            Some(true) => "o",
-                            // Otherwise, regular Yellow.
-                            _ => "y",
-                        },
-                    },
-                    // The actual text wrapped by this ANSI color code.
-                    m.text,
-                    // The "reset back to the normal color" code.
-                    "\x07x",
-                ],
-            }
-        })
-        .collect()
-}
-
-#[cfg(not(feature = "colors"))]
-fn colorize(line: &str) -> &str {
-    line
 }

--- a/macroquest/src/mq.rs
+++ b/macroquest/src/mq.rs
@@ -89,7 +89,17 @@ pub fn paths() -> &'static Paths<'static> {
     })
 }
 
-#[allow(missing_docs)]
+/// Write a line of text into the MacroQuest console
+///
+/// This text will show up in the MacroQuest console (`ctrl \`), or in MQ2Chat
+/// or MQ2ChatWnd depending on which plugins you have loaded. It supports any of
+/// the MacroQuest colors (see
+/// [Color Codes](https://docs.macroquest.org/reference/commands/echo/?h=#color-codes))
+/// or any of the standard 8 ANSI color codes (as well as the "Faint" intensity
+/// modifier for dimmed or darker text).
+///
+/// This will use the the default [`ChatColor`], if you want to set a specific
+/// [`ChatColor`], see [`write_chat_color`].
 pub fn write_chat<'a, S>(line: S)
 where
     S: Into<Cow<'a, str>>,
@@ -97,7 +107,17 @@ where
     write_chat_color(line, ChatColor::default());
 }
 
-#[allow(missing_docs)]
+/// Write a line of text into the MacroQuest console
+///
+/// This text will show up in the MacroQuest console (`ctrl \`), or in MQ2Chat
+/// or MQ2ChatWnd depending on which plugins you have loaded. It supports any of
+/// the MacroQuest colors (see
+/// [Color Codes](https://docs.macroquest.org/reference/commands/echo/?h=#color-codes))
+/// or any of the standard 8 ANSI color codes (as well as the "Faint" intensity
+/// modifier for dimmed or darker text).
+///
+/// You must specify which [`ChatColor`] the line of text should use, if you
+/// want to just use the default, see [`write_chat`].
 pub fn write_chat_color<'a, S>(line: S, color: ChatColor)
 where
     S: Into<Cow<'a, str>>,

--- a/macroquest/src/mq.rs
+++ b/macroquest/src/mq.rs
@@ -105,6 +105,11 @@ where
     mqlib::write_chat_color(&colorize_line(line.into()), color.into());
 }
 
+/// Convert the standard 8 ANSI color codes into MacroQuest color codes
+///
+/// While MacroQuest has it's own color codes, the ANSI codes are far more
+/// standard and will have crates already available to make working with them
+/// easy.
 fn colorize_line<'a, S>(line: S) -> Cow<'a, str>
 where
     S: Into<Cow<'a, str>>,
@@ -189,5 +194,73 @@ impl io::Write for ConsoleWriter {
 
     fn flush(&mut self) -> io::Result<()> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use colored::Colorize;
+
+    use super::*;
+
+    #[test]
+    fn test_colorize_returns_borrowed_when_no_color() {
+        assert!(matches!(
+            colorize_line("this is a line with no formatting"),
+            Cow::Borrowed(..)
+        ));
+    }
+
+    #[test]
+    fn test_colorize_returns_same_when_no_color() {
+        assert_eq!(
+            colorize_line("this is a line with no formatting"),
+            "this is a line with no formatting"
+        );
+    }
+
+    #[test]
+    fn test_colorize_leaves_mq_colors_alone() {
+        assert_eq!(
+            colorize_line(
+                "\x07b\x07-b\x07g\x07-g\x07m\x07-m\x07o\x07-o\x07p\x07-p\x07r\x07-r\x07t\x07-t\x07u\x07-u\x07w\x07-w\x07y\x07-ysome text\x07x"
+            ),
+            "\x07b\x07-b\x07g\x07-g\x07m\x07-m\x07o\x07-o\x07p\x07-p\x07r\x07-r\x07t\x07-t\x07u\x07-u\x07w\x07-w\x07y\x07-ysome text\x07x"
+        );
+    }
+
+    #[test]
+    fn test_colorize_converts_ansi() {
+        use super::colorize_line as c;
+
+        assert_eq!(c("black".black().to_string()), "\x07bblack\x07x");
+        assert_eq!(c("black".black().dimmed().to_string()), "\x07-bblack\x07x");
+
+        assert_eq!(c("green".green().to_string()), "\x07ggreen\x07x");
+        assert_eq!(c("green".green().dimmed().to_string()), "\x07-ggreen\x07x");
+
+        assert_eq!(c("magenta".magenta().to_string()), "\x07pmagenta\x07x");
+        assert_eq!(
+            c("magenta".magenta().dimmed().to_string()),
+            "\x07-pmagenta\x07x"
+        );
+
+        assert_eq!(c("red".red().to_string()), "\x07rred\x07x");
+        assert_eq!(c("red".red().dimmed().to_string()), "\x07-rred\x07x");
+
+        assert_eq!(c("cyan".cyan().to_string()), "\x07tcyan\x07x");
+        assert_eq!(c("cyan".cyan().dimmed().to_string()), "\x07-tcyan\x07x");
+
+        assert_eq!(c("blue".blue().to_string()), "\x07ublue\x07x");
+        assert_eq!(c("blue".blue().dimmed().to_string()), "\x07-ublue\x07x");
+
+        assert_eq!(c("white".white().to_string()), "\x07wwhite\x07x");
+        assert_eq!(c("white".white().dimmed().to_string()), "\x07-wwhite\x07x");
+
+        assert_eq!(c("yellow".yellow().to_string()), "\x07oyellow\x07x");
+        assert_eq!(
+            c("yellow".yellow().dimmed().to_string()),
+            "\x07-oyellow\x07x"
+        );
     }
 }

--- a/macroquest/src/mq.rs
+++ b/macroquest/src/mq.rs
@@ -336,6 +336,8 @@ mod tests {
     fn test_colorize_converts_ansi() {
         use super::colorize_line as c;
 
+        colored::control::set_override(true);
+
         assert_eq!(c("black".black().to_string()), "\x07bblack\x07x");
         assert_eq!(c("black".black().dimmed().to_string()), "\x07-bblack\x07x");
 
@@ -365,6 +367,8 @@ mod tests {
             c("yellow".yellow().dimmed().to_string()),
             "\x07-oyellow\x07x"
         );
+
+        colored::control::unset_override();
     }
 
     struct TestChatWriter {

--- a/macroquest/src/mq.rs
+++ b/macroquest/src/mq.rs
@@ -132,30 +132,17 @@ where
                             // Map the ANSI colors to the MacroQuest color codes.
                             //
                             // MacroQuest supports 10 color codes instead of the
-                            // standard 8, adding Purple and Orange. To support
-                            // these two colors we'll use a similiar color with the
-                            // blink ANSI code set.
+                            // standard 8, adding Purple and Orange, so we'll only
+                            // map the 8 standard ANSI codes.
                             match fg {
                                 Color::Black | Color::BrightBlack => "b",
                                 Color::Green | Color::BrightGreen => "g",
-                                Color::Magenta | Color::BrightMagenta => {
-                                    match m.blink {
-                                        // Purple is blinking Magenta.
-                                        Some(true) => "p",
-                                        // Otherwise, regular Magenta.
-                                        _ => "m",
-                                    }
-                                }
+                                Color::Magenta | Color::BrightMagenta => "p",
                                 Color::Red | Color::BrightRed => "r",
                                 Color::Cyan | Color::BrightCyan => "t",
                                 Color::Blue | Color::BrightBlue => "u",
                                 Color::White | Color::BrightWhite => "w",
-                                Color::Yellow | Color::BrightYellow => match m.blink {
-                                    // Orangle is blinking Yellow.
-                                    Some(true) => "o",
-                                    // Otherwise, regular Yellow.
-                                    _ => "y",
-                                },
+                                Color::Yellow | Color::BrightYellow => "o",
                             },
                             // The actual text wrapped by this ANSI color code.
                             m.text,


### PR DESCRIPTION
- Our exposed `write_chat` functions natively handle ANSI colors now, instead of relying on the `ConsoleWriter` to do it.
- Avoid allocating a ``String`` in the case that the value passed to ``write_chat`` or ``write_chat_color`` does not have any ANSI codes in them that need to be stripped.
- Refactor ``ConsoleWriter``, to align better with ``std::io::stdout`` and to ensure we handle partial lines better,
- Remove the blink hack for adding 2 extra colors, we no longer expose them and if you want that level of control you need to use the MacroQuest color codes directly.
- Remove the "colors" feature, we just now always support ANSI colors.
- Document chat handling better.