### PR TITLE
Move Plugin Initialization from DllMain to InitializePlugin

### DIFF
--- a/examples/MQRustBasic/src/lib.rs
+++ b/examples/MQRustBasic/src/lib.rs
@@ -12,12 +12,18 @@ const PLUGIN_NAME: &str = env!("CARGO_PKG_NAME");
 
 use macroquest::eq;
 use macroquest::log::{ConsoleLogger, FileLogger, LevelFilter, Logger};
-use macroquest::plugin::Hooks;
+use macroquest::plugin::{Hooks, New};
 
 macroquest::plugin::setup!(MQRustSimple);
 
 #[derive(Debug, Default)]
 struct MQRustSimple {}
+
+impl New for MQRustSimple {
+    fn new() -> Self {
+        MQRustSimple {}
+    }
+}
 
 #[macroquest::plugin::hooks]
 impl Hooks for MQRustSimple {

--- a/examples/MQRustBasic/src/lib.rs
+++ b/examples/MQRustBasic/src/lib.rs
@@ -12,14 +12,14 @@ const PLUGIN_NAME: &str = env!("CARGO_PKG_NAME");
 
 use macroquest::eq;
 use macroquest::log::{ConsoleLogger, FileLogger, LevelFilter, Logger};
-use macroquest::plugin::{Hooks, New};
+use macroquest::plugin::{Hooks, Plugin};
 
 macroquest::plugin::setup!(MQRustSimple);
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 struct MQRustSimple {}
 
-impl New for MQRustSimple {
+impl Plugin for MQRustSimple {
     fn new() -> Self {
         MQRustSimple {}
     }

--- a/macroquest-proc-macros/src/plugin/hooks.rs
+++ b/macroquest-proc-macros/src/plugin/hooks.rs
@@ -88,10 +88,19 @@ impl ToTokens for Hooks {
             else {
                 abort!(hook, "The hook must be a supported MacroQuest hook");
             };
-            let hook_kind = format_ident!("{}", kind.to_string());
 
-            quote! {
-                macroquest::plugin::hook!(#hook_kind(PLUGIN));
+            match kind {
+                // InitializePlugin and ShutdownPlugin are handled by
+                // macroquest::plugin::setup!.
+                Kind::InitializePlugin | Kind::ShutdownPlugin => quote! {},
+                // Everything else is handled here, and we just emit the private
+                // macroquest::plugin::hook! invocation for each defined hook.
+                _ => {
+                    let hook_kind = format_ident!("{}", kind.to_string());
+                    quote! {
+                        macroquest::plugin::hook!(#hook_kind(PLUGIN));
+                    }
+                }
             }
             .to_tokens(tokens);
         }

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -25,10 +25,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", optional = true }
 tracing-appender = { version = "0.2", optional = true }
 typed-builder = "0.18.1"
-windows = { version = "0.*", features = [
-    "Win32_Foundation",
-    "Win32_System_SystemServices",
-] }
 
 
 [dev-dependencies]

--- a/macroquest/Cargo.toml
+++ b/macroquest/Cargo.toml
@@ -14,6 +14,7 @@ keywords.workspace = true
 macroquest-sys = { workspace = true, optional = true }
 macroquest-proc-macros = { workspace = true }
 
+arc-swap = "1.6.0"
 cansi = "2.2.1"
 memchr = "2"
 num_enum = "0.7.2"

--- a/macroquest/src/log.rs
+++ b/macroquest/src/log.rs
@@ -23,10 +23,15 @@
 //!
 //! ```
 //! # use macroquest::eq::ChatColor;
-//! # use macroquest::plugin::Hooks;
+//! # use macroquest::plugin::{Hooks, Plugin};
 //! # macroquest::plugin::setup!(MQRustLogging);
-//! # #[derive(Debug, Default)]
+//! # #[derive(Debug)]
 //! # struct MQRustLogging {}
+//! # impl Plugin for MQRustLogging {
+//! #     fn new() -> Self {
+//! #         MQRustLogging { }
+//! #     }
+//! # }
 //! use macroquest::log::debug;
 //!
 //! #[macroquest::plugin::hooks]
@@ -46,10 +51,15 @@
 //!
 //! ```
 //! # use macroquest::log::{ConsoleLogger, FileLogger, Logger, LevelFilter};
-//! # use macroquest::plugin::Hooks;
+//! # use macroquest::plugin::{Hooks, Plugin};
 //! # macroquest::plugin::setup!(MQRustLogging);
-//! # #[derive(Debug, Default)]
+//! # #[derive(Debug)]
 //! # struct MQRustLogging {}
+//! # impl Plugin for MQRustLogging {
+//! #     fn new() -> Self {
+//! #         MQRustLogging { }
+//! #     }
+//! # }
 //! #[macroquest::plugin::hooks]
 //! impl Hooks for MQRustLogging {
 //!     fn initialize(&self) {


### PR DESCRIPTION
Doing anything complex in a `DllMain` is fraught with peril, and we already have perfectly good "initialize things" and "deinitialize things" hooks in `InitializePlugin` and `ShutdownPlugin`, so we'll just go ahead and use those, which solves a number of possible bugs (which can even include deadlocks) and makes these APIs more misuse resistant.

We also switch from using a `std::sync::OnceLock` to a `arc_swap::ArcSwap` for our global plugin instance.

The `OnceLock` is good, but for our uses it's effectively immutable once it's been initialized so you can't de-initialize the plugin. 

We only *technically* need to de-initialize when the plugin is being unloaded, so we could just leave the `OnceLock` initialized and let the OS reclaim the memory when the `DLL` is unloaded, but that will (I believe) prevent any `Drop` implementations from running which may be surprising behavior.

Needing to mutate the global plugin reference means we need some sort of synchronization primitive (or `unsafe`... but we're trying to avoid that!), which generally needs `Mutex` or `RwLock`.

Accessing this global is almost certainly only going to happen on the main thread, so a `Mutex` would probably be fine since it would pretty much always ever be an uncontested lock which has a pretty fast path (generally). However, if we ever get into a situation where accessing the global is happening from multiple threads then the `Mutex` will quickly break down in performance as it serializes access to the plugin, which is particularly bad since 99.99% of cases accessing the plugin is a read only operation and we only need to mutate it in `InitializePlugin` and `ShutdownPlugin`.

We could use `RwLock`, but it's generally always pretty slow, and again gets really slow under contention (but again, unlikely to happen in practice anyways).

Instead we go a different way, and we use the excellent [arc-swap](https://crates.io/crates/arc-swap) crate, which lets us have a reference counted reference to our global plugin, but one we can "swap" with another reference counted reference. If we then store a `Option<Plugin>` in the `Arc` instead of just `Plugin`, that means we can easily swap from `None`, to `Some(Plugin)` in `InitializePlugin`, and then back to `None` in `ShutdownPlugin`. This will ensure that all of our `Drop` traits have a chance to run.

Accessing the `ArcSwap` instance for reading utilizes a lock-free algorithm, so it will be impossible to ever have it end up in a dead lock, and will typically always be `wait-free` as well. It is generally at least as fast as an uncontended `Mutex`, but maintains it's speed even under contention. 

It also just matches our use case better, we don't really care about broadly mutating the underlying reference, we just simply want to be able to initialize it and de-initialize it safely.

